### PR TITLE
enforce boolean attribute notation

### DIFF
--- a/react/.eslintrc.js
+++ b/react/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
       {
         allowComputed: true
       }
-    ]
+    ],
+    'react/jsx-boolean-value': 'error'
   }
 };

--- a/react/fixture.jsx
+++ b/react/fixture.jsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 export default class Fixture extends React.Component {
 	render () {
-		return <div>Hello World</div>;
+		return <div disabled>Hello World</div>;
 	}
 }


### PR DESCRIPTION
This rule will force us to use the more concise and html5-y form of boolean attributes in react.

Instead of:
```html
<MyComponent disabled={true} />
```
You do:
```html
<MyComponent disabled />
```
Or when the boolean should be `false`
```html
<MyComponent disabled={false} />
```
You simply don't include it:
```html
<MyComponent />
```

See the react docs on the matter: https://facebook.github.io/react/docs/jsx-in-depth.html#props-default-to-true